### PR TITLE
[Feat] 깃허브 OAuth2 로그인 구현

### DIFF
--- a/src/main/java/com/dongyang/core/domain/auth/api/AuthController.java
+++ b/src/main/java/com/dongyang/core/domain/auth/api/AuthController.java
@@ -34,7 +34,7 @@ public class AuthController {
 
 	@Operation(summary = "OAuth2 소셜 회원가입")
 	@PostMapping("/auth/signup")
-	public ApiResponse<TokenResponse> kakaoSignUp(@Valid @RequestBody SignUpRequest request) {
+	public ApiResponse<TokenResponse> signUp(@Valid @RequestBody SignUpRequest request) {
 		AuthService authService = authServiceProvider.getAuthService(request.getSocialType());
 		Long memberId = authService.signUp(request);
 		TokenResponse tokenInfo = createTokenService.createTokenInfo(memberId);
@@ -43,7 +43,7 @@ public class AuthController {
 
 	@Operation(summary = "OAuth2 소셜 로그인")
 	@PostMapping("/auth/login")
-	public ApiResponse<TokenResponse> kakaoLogin(@Valid @RequestBody LoginRequest request) {
+	public ApiResponse<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
 		AuthService authService = authServiceProvider.getAuthService(request.getSocialType());
 		Long memberId = authService.login(request);
 		TokenResponse tokenInfo = createTokenService.createTokenInfo(memberId);

--- a/src/main/java/com/dongyang/core/domain/auth/api/AuthController.java
+++ b/src/main/java/com/dongyang/core/domain/auth/api/AuthController.java
@@ -32,23 +32,24 @@ public class AuthController {
 	private final CreateTokenService createTokenService;
 	private final CommonAuthService commonAuthService;
 
-	@Operation(summary = "카카오 소셜 회원가입")
+	@Operation(summary = "OAuth2 소셜 회원가입")
 	@PostMapping("/auth/signup")
-	public ApiResponse<TokenResponse> signUp(@Valid @RequestBody SignUpRequest request) {
+	public ApiResponse<TokenResponse> kakaoSignUp(@Valid @RequestBody SignUpRequest request) {
 		AuthService authService = authServiceProvider.getAuthService(request.getSocialType());
 		Long memberId = authService.signUp(request);
 		TokenResponse tokenInfo = createTokenService.createTokenInfo(memberId);
-		return ApiResponse.success(KAKAO_LOGIN_SUCCESS, tokenInfo);
+		return ApiResponse.success(OAUTH_LOGIN_SUCCESS, tokenInfo);
 	}
 
-	@Operation(summary = "카카오 소셜 로그인")
+	@Operation(summary = "OAuth2 소셜 로그인")
 	@PostMapping("/auth/login")
-	public ApiResponse<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
+	public ApiResponse<TokenResponse> kakaoLogin(@Valid @RequestBody LoginRequest request) {
 		AuthService authService = authServiceProvider.getAuthService(request.getSocialType());
 		Long memberId = authService.login(request);
 		TokenResponse tokenInfo = createTokenService.createTokenInfo(memberId);
-		return ApiResponse.success(KAKAO_LOGIN_SUCCESS, tokenInfo);
+		return ApiResponse.success(OAUTH_LOGIN_SUCCESS, tokenInfo);
 	}
+
 
 	@Operation(summary = "[인증] 로그아웃")
 	@Auth

--- a/src/main/java/com/dongyang/core/domain/auth/service/AuthServiceProvider.java
+++ b/src/main/java/com/dongyang/core/domain/auth/service/AuthServiceProvider.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
+import com.dongyang.core.domain.auth.service.impl.GithubAuthService;
 import com.dongyang.core.domain.auth.service.impl.KakaoAuthService;
 import com.dongyang.core.domain.member.MemberSocialType;
 
@@ -19,10 +20,12 @@ public class AuthServiceProvider {
 	private static final Map<MemberSocialType, AuthService> authServiceMap = new HashMap<>();
 
 	private final KakaoAuthService kakaoAuthService;
+	private final GithubAuthService githubAuthService;
 
 	@PostConstruct
 	void initializeAuthServicesMap() {
 		authServiceMap.put(MemberSocialType.KAKAO, kakaoAuthService);
+		authServiceMap.put(MemberSocialType.GITHUB, githubAuthService);
 	}
 
 	public AuthService getAuthService(MemberSocialType socialType) {

--- a/src/main/java/com/dongyang/core/domain/auth/service/dto/request/SignUpRequest.java
+++ b/src/main/java/com/dongyang/core/domain/auth/service/dto/request/SignUpRequest.java
@@ -30,7 +30,7 @@ public class SignUpRequest {
 
 
 	public CreateMemberRequest toCreateMemberDto(KakaoProfileResponse response) {
-		return CreateMemberRequest.of(response.getId(), socialType, response.getProperties().nickname, response.getProperties().thumbnail_image);
+		return CreateMemberRequest.of(response.getId(), socialType, response.getProperties().nickname, response.getProperties().thumbnailImage);
 	}
 
 	public CreateMemberRequest toCreateMemberDto(GithubProfileResponse response) {

--- a/src/main/java/com/dongyang/core/domain/auth/service/dto/request/SignUpRequest.java
+++ b/src/main/java/com/dongyang/core/domain/auth/service/dto/request/SignUpRequest.java
@@ -2,6 +2,7 @@ package com.dongyang.core.domain.auth.service.dto.request;
 
 import com.dongyang.core.domain.member.MemberSocialType;
 import com.dongyang.core.domain.member.dto.CreateMemberRequest;
+import com.dongyang.core.external.client.auth.github.dto.response.GithubProfileResponse;
 import com.dongyang.core.external.client.auth.kakao.dto.response.KakaoProfileResponse;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -30,5 +31,9 @@ public class SignUpRequest {
 
 	public CreateMemberRequest toCreateMemberDto(KakaoProfileResponse response) {
 		return CreateMemberRequest.of(response.getId(), socialType, response.getProperties().nickname, response.getProperties().thumbnail_image);
+	}
+
+	public CreateMemberRequest toCreateMemberDto(GithubProfileResponse response) {
+		return CreateMemberRequest.of(response.getId(), socialType, response.getLogin(), response.getAvatarUrl());
 	}
 }

--- a/src/main/java/com/dongyang/core/domain/auth/service/impl/GithubAuthService.java
+++ b/src/main/java/com/dongyang/core/domain/auth/service/impl/GithubAuthService.java
@@ -1,0 +1,43 @@
+package com.dongyang.core.domain.auth.service.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dongyang.core.domain.auth.service.AuthService;
+import com.dongyang.core.domain.auth.service.dto.request.LoginRequest;
+import com.dongyang.core.domain.auth.service.dto.request.SignUpRequest;
+import com.dongyang.core.domain.member.Member;
+import com.dongyang.core.domain.member.MemberSocialType;
+import com.dongyang.core.domain.member.repository.MemberRepository;
+import com.dongyang.core.domain.member.service.MemberService;
+import com.dongyang.core.domain.member.service.MemberServiceUtils;
+import com.dongyang.core.external.client.auth.github.GithubApiCaller;
+import com.dongyang.core.external.client.auth.github.dto.response.GithubProfileResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class GithubAuthService implements AuthService {
+
+	private final GithubApiCaller githubApiCaller;
+
+	private final MemberRepository memberRepository;
+
+	private final MemberService memberService;
+
+	@Override
+	public Long signUp(SignUpRequest request) {
+		GithubProfileResponse response = githubApiCaller.getProfileInfo(request.getToken());
+		return memberService.registerMember(request.toCreateMemberDto(response));
+	}
+
+	@Override
+	public Long login(LoginRequest request) {
+		GithubProfileResponse response = githubApiCaller.getProfileInfo(request.getToken());
+		Member member = MemberServiceUtils.findMemberBySocialIdAndSocialType(memberRepository, response.getId(),
+			MemberSocialType.GITHUB);
+		return member.getId();
+	}
+}

--- a/src/main/java/com/dongyang/core/domain/member/MemberSocialType.java
+++ b/src/main/java/com/dongyang/core/domain/member/MemberSocialType.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum MemberSocialType {
-	KAKAO("카카오톡");
-
+	KAKAO("카카오톡"),
+	GITHUB("깃허브"),
+	;
 	private final String value;
 }

--- a/src/main/java/com/dongyang/core/external/client/auth/github/GithubApiCaller.java
+++ b/src/main/java/com/dongyang/core/external/client/auth/github/GithubApiCaller.java
@@ -1,0 +1,9 @@
+package com.dongyang.core.external.client.auth.github;
+
+import com.dongyang.core.external.client.auth.github.dto.response.GithubProfileResponse;
+
+public interface GithubApiCaller {
+
+	GithubProfileResponse getProfileInfo(String accessToken);
+
+}

--- a/src/main/java/com/dongyang/core/external/client/auth/github/WebClientGithubCaller.java
+++ b/src/main/java/com/dongyang/core/external/client/auth/github/WebClientGithubCaller.java
@@ -1,0 +1,37 @@
+package com.dongyang.core.external.client.auth.github;
+
+import static com.dongyang.core.global.common.constants.message.AuthErrorMessage.*;
+
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.dongyang.core.external.client.auth.github.dto.response.GithubProfileResponse;
+import com.dongyang.core.global.common.exception.model.BadGatewayException;
+import com.dongyang.core.global.common.exception.model.ValidationException;
+import com.dongyang.core.global.common.utils.MessageUtils;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@Component
+public class WebClientGithubCaller implements GithubApiCaller {
+
+	private final WebClient webClient;
+
+	@Override
+	public GithubProfileResponse getProfileInfo(String accessToken) {
+		return webClient.get()
+			.uri("https://api.github.com/user")
+			.headers(headers -> headers.setBearerAuth(accessToken))
+			.retrieve()
+			.onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
+				Mono.error(new ValidationException(
+					MessageUtils.generate(WRONG_OAUTH2_ACCESS_TOKEN_ERROR_MESSAGE, accessToken))))
+			.onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
+				Mono.error(new BadGatewayException(OAUTH2_LOGIN_ERROR_MESSAGE)))
+			.bodyToMono(GithubProfileResponse.class)
+			.block();
+	}
+}

--- a/src/main/java/com/dongyang/core/external/client/auth/github/dto/response/GithubProfileResponse.java
+++ b/src/main/java/com/dongyang/core/external/client/auth/github/dto/response/GithubProfileResponse.java
@@ -1,6 +1,7 @@
 package com.dongyang.core.external.client.auth.github.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -14,7 +15,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GithubProfileResponse {
 
 	private String login;	// 로그인한 유저 깃허브 ID

--- a/src/main/java/com/dongyang/core/external/client/auth/github/dto/response/GithubProfileResponse.java
+++ b/src/main/java/com/dongyang/core/external/client/auth/github/dto/response/GithubProfileResponse.java
@@ -1,0 +1,23 @@
+package com.dongyang.core.external.client.auth.github.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class GithubProfileResponse {
+
+	private String login;	// 로그인한 유저 깃허브 ID
+	private String id;
+	private String avatarUrl; // 깃허브 프로필 Url
+}

--- a/src/main/java/com/dongyang/core/external/client/auth/kakao/WebClientKakaoCaller.java
+++ b/src/main/java/com/dongyang/core/external/client/auth/kakao/WebClientKakaoCaller.java
@@ -28,9 +28,9 @@ public class WebClientKakaoCaller implements KakaoApiCaller {
 			.retrieve()
 			.onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
 				Mono.error(new ValidationException(
-					MessageUtils.generate(WRONG_KAKAO_ACCESS_TOKEN_ERROR_MESSAGE, accessToken))))
+					MessageUtils.generate(WRONG_OAUTH2_ACCESS_TOKEN_ERROR_MESSAGE, accessToken))))
 			.onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
-				Mono.error(new BadGatewayException(KAKAO_LOGIN_ERROR_MESSAGE)))
+				Mono.error(new BadGatewayException(OAUTH2_LOGIN_ERROR_MESSAGE)))
 			.bodyToMono(KakaoProfileResponse.class)
 			.block();
 	}

--- a/src/main/java/com/dongyang/core/external/client/auth/kakao/dto/response/KakaoProfileResponse.java
+++ b/src/main/java/com/dongyang/core/external/client/auth/kakao/dto/response/KakaoProfileResponse.java
@@ -23,8 +23,8 @@ public class KakaoProfileResponse {
 
 	public class Properties {
 		public String nickname;
-		public String profile_image;
-		public String thumbnail_image;
+		public String profileImage;
+		public String thumbnailImage;
 	}
 
 }

--- a/src/main/java/com/dongyang/core/external/client/auth/kakao/dto/response/KakaoProfileResponse.java
+++ b/src/main/java/com/dongyang/core/external/client/auth/kakao/dto/response/KakaoProfileResponse.java
@@ -1,6 +1,7 @@
 package com.dongyang.core.external.client.auth.kakao.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -14,7 +15,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class KakaoProfileResponse {
 
 	private String id;

--- a/src/main/java/com/dongyang/core/global/common/constants/message/AuthErrorMessage.java
+++ b/src/main/java/com/dongyang/core/global/common/constants/message/AuthErrorMessage.java
@@ -17,9 +17,9 @@ public class AuthErrorMessage {
 	public static String NEED_AUTH_ANNOTATION_ERROR_MESSAGE = "인증이 필요한 컨트롤러 입니다. @Auth 어노테이션을 붙여주세요.";
 	public static String CAN_NOT_GET_MEMBER_ID_ERROR_MESSAGE = "MEMBER_ID를 가져오지 못했습니다. (%s - %s)";
 
-	// Kakao Auth Error Message
-	public static String WRONG_KAKAO_ACCESS_TOKEN_ERROR_MESSAGE = "잘못된 카카오 액세스 토큰 (%s) 입니다.";
-	public static String KAKAO_LOGIN_ERROR_MESSAGE = "카카오 로그인 연동 중 에러가 발생하였습니다.";
+	// OAuth2 Error Message
+	public static String WRONG_OAUTH2_ACCESS_TOKEN_ERROR_MESSAGE = "잘못된 OAuth2 액세스 토큰 (%s) 입니다.";
+	public static String OAUTH2_LOGIN_ERROR_MESSAGE = "OAuth2 소셜 로그인 연동 중 에러가 발생하였습니다.";
 
 	// Admin Error Message
 	public static String ADMIN_ERROR_MESSAGE = "관리자에게만 허용된 요청입니다.";

--- a/src/main/java/com/dongyang/core/global/response/SuccessCode.java
+++ b/src/main/java/com/dongyang/core/global/response/SuccessCode.java
@@ -13,7 +13,7 @@ public enum SuccessCode {
 	 */
 	RECOMMEND_VARIABLE_NAME_SUCCESS(HttpStatus.OK, "변수명 추천 요청 성공"),
 	ADD_COMMENT_SUCCESS(HttpStatus.OK, "설명 주석 요청 성공"),
-	KAKAO_LOGIN_SUCCESS(HttpStatus.OK, "카카오 로그인 성공"),
+	OAUTH_LOGIN_SUCCESS(HttpStatus.OK, "소셜 OAuth2 로그인 성공"),
 	LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공"),
 	JWT_TOKEN_REISSUE_SUCCESS(HttpStatus.OK, "JWT 토큰 갱신 성공"),
 	;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,7 +7,7 @@ spring:
 
   sql:
     init:
-      mode: always
+      mode: never
       schema-locations: classpath:sql/schema.sql
       #data-locations: classpath:sql/data.sql
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #13 

## 🔑 Key Changes

1. 내용
- WebClient로 github 로그인 api에 요청보내서 유저정보 받아오기
- 유저정보 DB에 저장

## 📢 To Reviewers
- 문서들 참조하면서 맞는 방식으로 구현하였는데, 혹시 잘못된 부분 있는지 확인 부탁드립니다!(깃허브 로그인은 처음이라..!)

