### PR TITLE
[BUGFIX] Properties 클래스에도 @JsonNaming, @Getter 추가

### DIFF
--- a/src/main/java/com/dongyang/core/domain/auth/service/dto/request/SignUpRequest.java
+++ b/src/main/java/com/dongyang/core/domain/auth/service/dto/request/SignUpRequest.java
@@ -30,7 +30,7 @@ public class SignUpRequest {
 
 
 	public CreateMemberRequest toCreateMemberDto(KakaoProfileResponse response) {
-		return CreateMemberRequest.of(response.getId(), socialType, response.getProperties().nickname, response.getProperties().thumbnailImage);
+		return CreateMemberRequest.of(response.getId(), socialType, response.getNickname(), response.getThumbnailImage());
 	}
 
 	public CreateMemberRequest toCreateMemberDto(GithubProfileResponse response) {

--- a/src/main/java/com/dongyang/core/domain/auth/service/impl/KakaoAuthService.java
+++ b/src/main/java/com/dongyang/core/domain/auth/service/impl/KakaoAuthService.java
@@ -8,7 +8,6 @@ import com.dongyang.core.domain.auth.service.dto.request.LoginRequest;
 import com.dongyang.core.domain.auth.service.dto.request.SignUpRequest;
 import com.dongyang.core.domain.member.Member;
 import com.dongyang.core.domain.member.MemberSocialType;
-import com.dongyang.core.domain.member.dto.CreateMemberRequest;
 import com.dongyang.core.domain.member.repository.MemberRepository;
 import com.dongyang.core.domain.member.service.MemberService;
 import com.dongyang.core.domain.member.service.MemberServiceUtils;

--- a/src/main/java/com/dongyang/core/external/client/auth/kakao/dto/response/KakaoProfileResponse.java
+++ b/src/main/java/com/dongyang/core/external/client/auth/kakao/dto/response/KakaoProfileResponse.java
@@ -2,7 +2,6 @@ package com.dongyang.core.external.client.auth.kakao.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import lombok.AllArgsConstructor;
@@ -21,10 +20,20 @@ public class KakaoProfileResponse {
 	private String id;
 	private Properties properties;
 
+	@Getter
+	@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 	public class Properties {
-		public String nickname;
-		public String profileImage;
-		public String thumbnailImage;
+		private String nickname;
+
+		private String thumbnailImage;
+	}
+
+	public String getNickname() {
+		return properties.nickname;
+	}
+
+	public String getThumbnailImage() {
+		return properties.thumbnailImage;
 	}
 
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #16 

## 🔑 Key Changes

`thumbnailImage`, `nickname` 필드를 `KakaoProfileResponse` 클래스에서 관리하는 것이 아닌 `Properties`라는 새로운 클래스를 생성하여 관리하기 때문에
  - Properties 클래스에도 필드의 JsonNaming 형식을 SnakeCase으로 적용
  - Jackson 라이브러리가 바인딩 시에 private 필드를 사용하도록 해주기 위해 @Getter 애노테이션을 추가

## 📢 To Reviewers
-

