### PR TITLE
[FEAT] 토큰을 통한 유저 트래픽 제한 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
 
 	// Health Check
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	// Bucket4j
+	implementation group: 'com.github.vladimir-bukhtoyarov', name: 'bucket4j-core', version: '7.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dongyang/core/domain/gpt/api/GptController.java
+++ b/src/main/java/com/dongyang/core/domain/gpt/api/GptController.java
@@ -8,6 +8,7 @@ import com.dongyang.core.domain.gpt.dto.GptRequest;
 import com.dongyang.core.domain.gpt.dto.GptSolveAlgorithmRequest;
 import com.dongyang.core.domain.gpt.service.GptService;
 import com.dongyang.core.external.gpt.dto.gpt.GptQuestionResponse;
+import com.dongyang.core.global.common.interceptor.auth.Auth;
 import com.dongyang.core.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,6 +31,7 @@ public class GptController {
     @Operation(summary = "변수명 추천")
     @PostMapping("/gpt/recommendVariableName")
     @ResponseStatus(HttpStatus.OK)
+    @Auth
     public ApiResponse<GptQuestionResponse> recommendVariableName(@Valid @RequestBody GptRequest request) {
         return ApiResponse.success(RECOMMEND_VARIABLE_NAME_SUCCESS, gptService.recommendVariableName(request));
     }
@@ -37,6 +39,7 @@ public class GptController {
     @Operation(summary = "설명 주석 추가")
     @PostMapping("/gpt/addComment")
     @ResponseStatus(HttpStatus.OK)
+    @Auth
     public ApiResponse<GptQuestionResponse> addComment(@Valid @RequestBody GptRequest request) {
         return ApiResponse.success(ADD_COMMENT_SUCCESS, gptService.addComment(request));
     }
@@ -44,6 +47,7 @@ public class GptController {
     @Operation(summary = "코드 리팩토링")
     @PostMapping("/gpt/refactorCode")
     @ResponseStatus(HttpStatus.OK)
+    @Auth
     public ApiResponse<GptQuestionResponse> refactorCode(@Valid @RequestBody GptRequest request) {
         return ApiResponse.success(REFACTOR_CODE_SUCCESS, gptService.refactorCode(request));
     }
@@ -51,8 +55,8 @@ public class GptController {
     @Operation(summary = "알고리즘 문제 해설[BETA]")
     @PostMapping("/gpt/solveAlgorithm")
     @ResponseStatus(HttpStatus.OK)
+    @Auth
     public ApiResponse<GptQuestionResponse> solveAlgorithm(@Valid @RequestBody GptSolveAlgorithmRequest request) {
         return ApiResponse.success(REFACTOR_CODE_SUCCESS, gptService.solveAlgorithm(request));
     }
-
 }

--- a/src/main/java/com/dongyang/core/global/ExceptionController.java
+++ b/src/main/java/com/dongyang/core/global/ExceptionController.java
@@ -1,10 +1,27 @@
 package com.dongyang.core.global;
 
-import static com.dongyang.core.global.response.ErrorCode.*;
+import static com.dongyang.core.global.response.ErrorCode.BIND_EXCEPTION;
+import static com.dongyang.core.global.response.ErrorCode.INTERNAL_SERVER_ERROR;
+import static com.dongyang.core.global.response.ErrorCode.INVALID_FORMAT_EXCEPTION;
+import static com.dongyang.core.global.response.ErrorCode.METHOD_ARGUMENT_NOT_VALID_EXCEPTION;
+import static com.dongyang.core.global.response.ErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH_EXCEPTION;
+import static com.dongyang.core.global.response.ErrorCode.METHOD_NOT_ALLOWED_EXCEPTION;
+import static com.dongyang.core.global.response.ErrorCode.UN_SUPPORTED_MEDIA_TYPE_EXCEPTION;
 
-
+import com.dongyang.core.global.common.exception.model.BadGatewayException;
+import com.dongyang.core.global.common.exception.model.ConflictException;
+import com.dongyang.core.global.common.exception.model.ForbiddenException;
+import com.dongyang.core.global.common.exception.model.GptRequestValueException;
+import com.dongyang.core.global.common.exception.model.NotFoundException;
+import com.dongyang.core.global.common.exception.model.RateLimitException;
+import com.dongyang.core.global.common.exception.model.UnAuthorizedException;
+import com.dongyang.core.global.common.exception.model.ValidationException;
+import com.dongyang.core.global.common.exception.model.WebClientException;
+import com.dongyang.core.global.response.ApiResponse;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import java.util.Objects;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
@@ -17,24 +34,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
-import com.dongyang.core.global.common.exception.model.BadGatewayException;
-import com.dongyang.core.global.common.exception.model.UnAuthorizedException;
-import com.dongyang.core.global.common.exception.model.ConflictException;
-import com.dongyang.core.global.common.exception.model.ForbiddenException;
-import com.dongyang.core.global.common.exception.model.GptRequestValueException;
-import com.dongyang.core.global.common.exception.model.NotFoundException;
-import com.dongyang.core.global.common.exception.model.ValidationException;
-import com.dongyang.core.global.common.exception.model.WebClientException;
-import com.dongyang.core.global.response.ApiResponse;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 @RequiredArgsConstructor
 @RestControllerAdvice
-public class ControllerAdvice {
+public class ExceptionController {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(BindException.class)
@@ -145,6 +148,17 @@ public class ControllerAdvice {
     protected ApiResponse<Object> handleHttpMediaTypeException(final HttpMediaTypeException exception) {
         log.error(exception.getMessage(), exception);
         return ApiResponse.error(UN_SUPPORTED_MEDIA_TYPE_EXCEPTION);
+    }
+
+    /**
+     * 429 Too Many Requests
+     */
+    @ResponseStatus(HttpStatus.TOO_MANY_REQUESTS)
+    @ExceptionHandler(RateLimitException.class)
+    protected ApiResponse<Object> handleRateLimitException(final RateLimitException exception) {
+        System.out.println("여기여요");
+        log.error(exception.getMessage(), exception);
+        return ApiResponse.error(exception.getErrorCode(), exception.getMessage());
     }
 
     /**

--- a/src/main/java/com/dongyang/core/global/common/exception/model/BadGatewayException.java
+++ b/src/main/java/com/dongyang/core/global/common/exception/model/BadGatewayException.java
@@ -11,5 +11,4 @@ public class BadGatewayException extends CustomException {
 	public BadGatewayException(String message, ErrorCode errorCode) {
 		super(message, errorCode);
 	}
-
 }

--- a/src/main/java/com/dongyang/core/global/common/exception/model/ConflictException.java
+++ b/src/main/java/com/dongyang/core/global/common/exception/model/ConflictException.java
@@ -7,5 +7,4 @@ public class ConflictException extends CustomException {
     public ConflictException(String message, ErrorCode errorCode) {
         super(message, errorCode);
     }
-
 }

--- a/src/main/java/com/dongyang/core/global/common/exception/model/CustomException.java
+++ b/src/main/java/com/dongyang/core/global/common/exception/model/CustomException.java
@@ -1,7 +1,9 @@
 package com.dongyang.core.global.common.exception.model;
 
 import com.dongyang.core.global.response.ErrorCode;
+import lombok.Getter;
 
+@Getter
 public class CustomException extends RuntimeException {
     private ErrorCode errorCode;
 
@@ -23,11 +25,12 @@ public class CustomException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
-    public CustomException(String message) {
-        super(message);
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
     }
 
-    public ErrorCode getErrorCode() {
-        return errorCode;
+    public CustomException(String message) {
+        super(message);
     }
 }

--- a/src/main/java/com/dongyang/core/global/common/exception/model/ForbiddenException.java
+++ b/src/main/java/com/dongyang/core/global/common/exception/model/ForbiddenException.java
@@ -7,5 +7,4 @@ public class ForbiddenException extends CustomException {
 	public ForbiddenException(String message, ErrorCode errorCode) {
 		super(message, errorCode);
 	}
-
 }

--- a/src/main/java/com/dongyang/core/global/common/exception/model/IllegalArgumentException.java
+++ b/src/main/java/com/dongyang/core/global/common/exception/model/IllegalArgumentException.java
@@ -1,0 +1,9 @@
+package com.dongyang.core.global.common.exception.model;
+
+import com.dongyang.core.global.response.ErrorCode;
+
+public class IllegalArgumentException extends CustomException {
+    public IllegalArgumentException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/dongyang/core/global/common/exception/model/IllegalArgumentException.java
+++ b/src/main/java/com/dongyang/core/global/common/exception/model/IllegalArgumentException.java
@@ -3,6 +3,7 @@ package com.dongyang.core.global.common.exception.model;
 import com.dongyang.core.global.response.ErrorCode;
 
 public class IllegalArgumentException extends CustomException {
+
     public IllegalArgumentException(ErrorCode errorCode) {
         super(errorCode);
     }

--- a/src/main/java/com/dongyang/core/global/common/exception/model/JsonProcessingException.java
+++ b/src/main/java/com/dongyang/core/global/common/exception/model/JsonProcessingException.java
@@ -9,5 +9,4 @@ public class JsonProcessingException extends CustomException {
 	public JsonProcessingException(String message) {
 		super(message);
 	}
-
 }

--- a/src/main/java/com/dongyang/core/global/common/exception/model/RateLimitException.java
+++ b/src/main/java/com/dongyang/core/global/common/exception/model/RateLimitException.java
@@ -3,6 +3,7 @@ package com.dongyang.core.global.common.exception.model;
 import com.dongyang.core.global.response.ErrorCode;
 
 public class RateLimitException extends CustomException{
+
 	public RateLimitException(ErrorCode errorCode) {
 		super(errorCode);
 	}

--- a/src/main/java/com/dongyang/core/global/common/exception/model/RateLimitException.java
+++ b/src/main/java/com/dongyang/core/global/common/exception/model/RateLimitException.java
@@ -1,0 +1,9 @@
+package com.dongyang.core.global.common.exception.model;
+
+import com.dongyang.core.global.response.ErrorCode;
+
+public class RateLimitException extends CustomException{
+	public RateLimitException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/dongyang/core/global/common/filter/exception/ExceptionFilter.java
+++ b/src/main/java/com/dongyang/core/global/common/filter/exception/ExceptionFilter.java
@@ -1,0 +1,44 @@
+package com.dongyang.core.global.common.filter.exception;
+
+
+import com.dongyang.core.global.common.exception.model.CustomException;
+import com.dongyang.core.global.common.exception.model.IllegalArgumentException;
+import com.dongyang.core.global.common.exception.model.RateLimitException;
+import com.dongyang.core.global.response.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(Integer.MIN_VALUE)
+@Slf4j
+public class ExceptionFilter implements Filter {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        try {
+            chain.doFilter(request, response);
+        } catch (RateLimitException | IllegalArgumentException exception) {
+            setErrorResponse((HttpServletResponse) response, exception);
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, CustomException exception) throws IOException {
+        ApiResponse<Object> errorResponse = ApiResponse.error(exception.getErrorCode());
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(exception.getErrorCode().getHttpStatusCode());
+    }
+}

--- a/src/main/java/com/dongyang/core/global/common/filter/exception/ExceptionHandlerFilter.java
+++ b/src/main/java/com/dongyang/core/global/common/filter/exception/ExceptionHandlerFilter.java
@@ -6,6 +6,7 @@ import com.dongyang.core.global.common.exception.model.IllegalArgumentException;
 import com.dongyang.core.global.common.exception.model.RateLimitException;
 import com.dongyang.core.global.response.ApiResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -22,7 +23,7 @@ import org.springframework.stereotype.Component;
 @Order(Integer.MIN_VALUE)
 @Slf4j
 public class ExceptionHandlerFilter implements Filter {
-    ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)

--- a/src/main/java/com/dongyang/core/global/common/filter/exception/ExceptionHandlerFilter.java
+++ b/src/main/java/com/dongyang/core/global/common/filter/exception/ExceptionHandlerFilter.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Order(Integer.MIN_VALUE)
 @Slf4j
-public class ExceptionFilter implements Filter {
+public class ExceptionHandlerFilter implements Filter {
     ObjectMapper objectMapper = new ObjectMapper();
 
     @Override

--- a/src/main/java/com/dongyang/core/global/common/filter/rateLimit/BucketPlan.java
+++ b/src/main/java/com/dongyang/core/global/common/filter/rateLimit/BucketPlan.java
@@ -14,7 +14,7 @@ public enum BucketPlan {
     //1시간에 3번 사용가능한 무제한 요금제
     MEMBER {
         public Bandwidth getLimit() {
-            return Bandwidth.classic(1, Refill.intervally(1, Duration.ofMinutes(1)));
+            return Bandwidth.classic(10, Refill.intervally(10, Duration.ofMinutes(1)));
         }
     };
 

--- a/src/main/java/com/dongyang/core/global/common/filter/rateLimit/BucketPlan.java
+++ b/src/main/java/com/dongyang/core/global/common/filter/rateLimit/BucketPlan.java
@@ -1,0 +1,31 @@
+package com.dongyang.core.global.common.filter.rateLimit;
+
+import com.dongyang.core.domain.member.MemberRole;
+import com.dongyang.core.global.common.exception.model.IllegalArgumentException;
+import com.dongyang.core.global.response.ErrorCode;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Refill;
+import java.time.Duration;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum BucketPlan {
+    //1시간에 3번 사용가능한 무제한 요금제
+    MEMBER {
+        public Bandwidth getLimit() {
+            return Bandwidth.classic(1, Refill.intervally(1, Duration.ofMinutes(1)));
+        }
+    };
+
+    public abstract Bandwidth getLimit();
+
+    public static Bandwidth findByMemberRole(MemberRole memberRole) {
+        return Arrays.stream(values())
+                .filter(v -> v.name().equals(memberRole.name()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_EXIST_MEMBER_ROLE))
+                .getLimit();
+    }
+
+}

--- a/src/main/java/com/dongyang/core/global/common/filter/rateLimit/BucketPlan.java
+++ b/src/main/java/com/dongyang/core/global/common/filter/rateLimit/BucketPlan.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum BucketPlan {
-    //1시간에 3번 사용가능한 무제한 요금제
+    // 총 5개의 토큰, 1분마다 5개의 토큰 충전
     MEMBER {
         public Bandwidth getLimit() {
             return Bandwidth.classic(5, Refill.intervally(5, Duration.ofMinutes(1)));

--- a/src/main/java/com/dongyang/core/global/common/filter/rateLimit/BucketPlan.java
+++ b/src/main/java/com/dongyang/core/global/common/filter/rateLimit/BucketPlan.java
@@ -27,5 +27,4 @@ public enum BucketPlan {
                 .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_EXIST_MEMBER_ROLE))
                 .getLimit();
     }
-
 }

--- a/src/main/java/com/dongyang/core/global/common/filter/rateLimit/BucketPlan.java
+++ b/src/main/java/com/dongyang/core/global/common/filter/rateLimit/BucketPlan.java
@@ -14,7 +14,7 @@ public enum BucketPlan {
     //1시간에 3번 사용가능한 무제한 요금제
     MEMBER {
         public Bandwidth getLimit() {
-            return Bandwidth.classic(10, Refill.intervally(10, Duration.ofMinutes(1)));
+            return Bandwidth.classic(5, Refill.intervally(5, Duration.ofMinutes(1)));
         }
     };
 

--- a/src/main/java/com/dongyang/core/global/common/filter/rateLimit/RateLimitBucketProvider.java
+++ b/src/main/java/com/dongyang/core/global/common/filter/rateLimit/RateLimitBucketProvider.java
@@ -1,0 +1,40 @@
+package com.dongyang.core.global.common.filter.rateLimit;
+
+import com.dongyang.core.domain.member.Member;
+import com.dongyang.core.domain.member.MemberRole;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import jakarta.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RateLimitBucketProvider {
+    private Map<Long, Bucket> buckets;
+
+    @PostConstruct
+    void initializeBuckets() {
+        buckets = new HashMap<>();
+    }
+
+    public Bucket getBucket(Member member) {
+        long memberId = member.getId();
+        if (!buckets.containsKey(memberId)) {
+            Bucket memberBucket = createBucketByRole(member.getRole());
+            buckets.put(memberId, memberBucket);
+
+            return memberBucket;
+        }
+        return buckets.get(memberId);
+    }
+
+    private Bucket createBucketByRole(MemberRole role) {
+        Bandwidth memberLimit = BucketPlan.findByMemberRole(role);
+        return Bucket.builder()
+                .addLimit(memberLimit)
+                .build();
+    }
+}

--- a/src/main/java/com/dongyang/core/global/common/filter/rateLimit/RateLimitFilter.java
+++ b/src/main/java/com/dongyang/core/global/common/filter/rateLimit/RateLimitFilter.java
@@ -1,0 +1,62 @@
+package com.dongyang.core.global.common.filter.rateLimit;
+
+import com.dongyang.core.domain.member.Member;
+import com.dongyang.core.domain.member.MemberRole;
+import com.dongyang.core.domain.member.repository.MemberRepository;
+import com.dongyang.core.domain.member.service.MemberServiceUtils;
+import com.dongyang.core.global.common.exception.model.RateLimitException;
+import com.dongyang.core.global.common.utils.JwtUtils;
+import com.dongyang.core.global.response.ErrorCode;
+import io.github.bucket4j.Bucket;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RateLimitFilter implements Filter {
+    private final JwtUtils jwtUtils;
+    private final RateLimitBucketProvider bucketProvider;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        String authorizationHeader = httpRequest.getHeader("Authorization");
+
+        // authorizationHeader가 없는 경우 Filter 동작 생략
+        if(authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        //authorizationHeader가 있는 경우 JWT AccessToken이 정상적인 경우 token을 사용
+
+        String accessToken = authorizationHeader.substring("Bearer ".length());
+        if (jwtUtils.validateToken(accessToken)) {
+            Long memberId = jwtUtils.getMemberIdFromJwt(accessToken);
+            Member member = MemberServiceUtils.findMemberById(memberRepository, memberId);
+            //관리자 계정이면 Token 사용X
+            if(member.getRole() == MemberRole.ADMIN) {
+                chain.doFilter(request, response);
+                return;
+            }
+
+            Bucket memberBucket = bucketProvider.getBucket(member);
+            if (!memberBucket.tryConsume(1)) {
+                throw new RateLimitException(ErrorCode.TOKEN_NOT_EXIST_EXCEPTION);
+            }
+            log.info(String.format("회원ID(%d)의 토큰 사용 : 잔여 토큰(%d)", memberId, memberBucket.getAvailableTokens()));
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/dongyang/core/global/response/ErrorCode.java
+++ b/src/main/java/com/dongyang/core/global/response/ErrorCode.java
@@ -1,82 +1,94 @@
 package com.dongyang.core.global.response;
 
-import static org.springframework.http.HttpStatus.*;
-
-import org.springframework.http.HttpStatus;
+import static org.springframework.http.HttpStatus.BAD_GATEWAY;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.TOO_MANY_REQUESTS;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ErrorCode {
-	/*
-		400 - BAD REQUEST
-	 */
-	REQUEST_VALIDATION_EXCEPTION(BAD_REQUEST, "잘못된 요청입니다."),
-	BIND_EXCEPTION(BAD_REQUEST, "요청 값을 바인딩하는 과정에서 오류가 발생하였습니다."),
-	METHOD_ARGUMENT_NOT_VALID_EXCEPTION(BAD_REQUEST, "요청 값이 검증되지 않은 값 입니다."),
-	VALIDATION_EXCEPTION(BAD_REQUEST, "검증되지 않은 값 입니다."),
-	METHOD_ARGUMENT_TYPE_MISMATCH_EXCEPTION(BAD_REQUEST, "요청 값의 타입이 잘못되었습니다."),
-	INVALID_FORMAT_EXCEPTION(BAD_REQUEST, "요청 값이 유효하지 않은 데이터입니다."),
-	GPT_REQUEST_VALUE_EXCEPTION(BAD_REQUEST, "요청 값의 function, content, language가 매칭되지 않거나 문제가 있습니다."),
-	INVALID_OAUTH2_TOKEN_ERROR(BAD_REQUEST, "잘못된 OAuth2 액세스 토큰 입니다"),
-	INVALID_GPT_API_INFO_ERROR(BAD_REQUEST, "잘못된 GPT API 요청입니다. API키 또는 요청 방식을 재확인 하세요."),
+    /*
+        400 - BAD REQUEST
+     */
+    REQUEST_VALIDATION_EXCEPTION(BAD_REQUEST, "잘못된 요청입니다."),
+    BIND_EXCEPTION(BAD_REQUEST, "요청 값을 바인딩하는 과정에서 오류가 발생하였습니다."),
+    METHOD_ARGUMENT_NOT_VALID_EXCEPTION(BAD_REQUEST, "요청 값이 검증되지 않은 값 입니다."),
+    VALIDATION_EXCEPTION(BAD_REQUEST, "검증되지 않은 값 입니다."),
+    METHOD_ARGUMENT_TYPE_MISMATCH_EXCEPTION(BAD_REQUEST, "요청 값의 타입이 잘못되었습니다."),
+    INVALID_FORMAT_EXCEPTION(BAD_REQUEST, "요청 값이 유효하지 않은 데이터입니다."),
+    GPT_REQUEST_VALUE_EXCEPTION(BAD_REQUEST, "요청 값의 function, content, language가 매칭되지 않거나 문제가 있습니다."),
+    INVALID_OAUTH2_TOKEN_ERROR(BAD_REQUEST, "잘못된 OAuth2 액세스 토큰 입니다"),
+    INVALID_GPT_API_INFO_ERROR(BAD_REQUEST, "잘못된 GPT API 요청입니다. API키 또는 요청 방식을 재확인 하세요."),
+    NOT_EXIST_MEMBER_ROLE(BAD_REQUEST, "존재하지 않는 회원 권한입니다."),
 
-	/*
-		401 - UNAUTHORIZED
-	 */
-	JWT_UNAUTHORIZED_ERROR(UNAUTHORIZED, "JWT 토큰이 존재하지 않거나 유효하지 않습니다."),
-	ADMIN_UNAUTHORIZED_ERROR(UNAUTHORIZED, "관리자 권한이 없습니다."),
+    /*
+        401 - UNAUTHORIZED
+     */
+    JWT_UNAUTHORIZED_ERROR(UNAUTHORIZED, "JWT 토큰이 존재하지 않거나 유효하지 않습니다."),
+    ADMIN_UNAUTHORIZED_ERROR(UNAUTHORIZED, "관리자 권한이 없습니다."),
 
-	/*
-		403 - FORBIDDEN
-	 */
-	FORBIDDEN_EXCEPTION(FORBIDDEN, "해당 요청에 대한 요청 권한이 존재하지 않습니다."),
+    /*
+        403 - FORBIDDEN
+     */
+    FORBIDDEN_EXCEPTION(FORBIDDEN, "해당 요청에 대한 요청 권한이 존재하지 않습니다."),
 
-	/*
-		404 - METHOD NOT ALLOWED
-	 */
-	NOT_FOUND_EXCEPTION(NOT_FOUND, "존재하지 않는 요청입니다."),
-	NOT_FOUND_MEMBER_EXCEPTION(NOT_FOUND, "존재하지 않거나 탈퇴한 유저입니다."),
-	NOT_FOUND_FAVORITE_ERROR(NOT_FOUND, "존재하지 않는 즐겨찾기 데이터입니다."),
+    /*
+        404 - NOT FOUND
+     */
+    NOT_FOUND_EXCEPTION(NOT_FOUND, "존재하지 않는 요청입니다."),
+    NOT_FOUND_MEMBER_EXCEPTION(NOT_FOUND, "존재하지 않거나 탈퇴한 유저입니다."),
+    NOT_FOUND_FAVORITE_ERROR(NOT_FOUND, "존재하지 않는 즐겨찾기 데이터입니다."),
 
-	/*
-		405 - METHOD NOT ALLOWED
-	 */
-	METHOD_NOT_ALLOWED_EXCEPTION(METHOD_NOT_ALLOWED, "잘못된 HTTP Method 요청입니다."),
+    /*
+        405 - METHOD NOT ALLOWED
+     */
+    METHOD_NOT_ALLOWED_EXCEPTION(METHOD_NOT_ALLOWED, "잘못된 HTTP Method 요청입니다."),
 
-	/*
-		409 - CONFLICT
-	*/
-	CONFLICT_EXCEPTION(CONFLICT, "데이터를 처리하는 과정에서 충돌이 발생하였습니다."),
-	CONFLICT_MEMBER_EXCEPTION(CONFLICT, "이미 존재하는 회원입니다."),
+    /*
+        409 - CONFLICT
+    */
+    CONFLICT_EXCEPTION(CONFLICT, "데이터를 처리하는 과정에서 충돌이 발생하였습니다."),
+    CONFLICT_MEMBER_EXCEPTION(CONFLICT, "이미 존재하는 회원입니다."),
 
-	/*
-		415 - UN SUPPORTED MEDIA TYPE
-	*/
-	UN_SUPPORTED_MEDIA_TYPE_EXCEPTION(UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 미디어 타입입니다."),
+    /*
+        415 - UN SUPPORTED MEDIA TYPE
+    */
+    UN_SUPPORTED_MEDIA_TYPE_EXCEPTION(UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 미디어 타입입니다."),
 
-	/*
-		500 - INTERNAL SERVER ERROR
-	*/
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 에러가 발생하였습니다."),
+    /*
+        429 - TOO MANY REQUESTS
+    */
+    TOKEN_NOT_EXIST_EXCEPTION(TOO_MANY_REQUESTS, "잔여 요청 토큰이 존재하지 않습니다. 잠시후 다시 시도해주세요."),
 
-	/*
-		502- BAD GATEWAY
-	 */
-	BAD_GATEWAY_ERROR(BAD_GATEWAY, "외부 연동 중 에러가 발생하였습니다."),
-	OAUTH2_BAD_GATEWAY_ERROR(BAD_GATEWAY, "OAuth2 소셜 로그인 연동 중 에러가 발생하였습니다."),
-	GPT_BAD_GATEWAY_ERROR(BAD_GATEWAY, "GPT API 연동 중 에러가 발생하였습니다."),
+    /*
+        500 - INTERNAL SERVER ERROR
+    */
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 에러가 발생하였습니다."),
 
-	;
+    /*
+        502- BAD GATEWAY
+     */
+    BAD_GATEWAY_ERROR(BAD_GATEWAY, "외부 연동 중 에러가 발생하였습니다."),
+    OAUTH2_BAD_GATEWAY_ERROR(BAD_GATEWAY, "OAuth2 소셜 로그인 연동 중 에러가 발생하였습니다."),
+    GPT_BAD_GATEWAY_ERROR(BAD_GATEWAY, "GPT API 연동 중 에러가 발생하였습니다."),
 
-	private final HttpStatus httpStatus;
-	private final String message;
+    ;
 
-	public int getHttpStatusCode() {
-		return httpStatus.value();
-	}
+    private final HttpStatus httpStatus;
+    private final String message;
 
+    public int getHttpStatusCode() {
+        return httpStatus.value();
+    }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #25 

## 🔑 Key Changes

#### 1. Bucket4j를 통해 유저 트래픽 제한 기능 구현
  - 1분 당 최대 n번 요청 가능
  - 1분 뒤에 다시 n개의 토큰 충전
  - MEMBER 권한은 1분에 5개 토큰 충천
#### 2. MemberRole에 따라 다른 Token갯수 처리
  - 아직은 MEMBER, ADMIN 밖에 존재하지 않아서 구분이 없음
#### 3. MemberRole이 ADMIN인 맴버는 Token Filter를 통과
#### 4. ExceptionHandlerFilter 사용하여 Filter 예외처리
  - 1순위로 동작하는 필터임.

## 📢 To Reviewers
-

