### PR TITLE
[FEAT] Redis, JPA 트랜잭션 통합

### DIFF
--- a/src/main/java/com/dongyang/core/api/auth/AuthController.java
+++ b/src/main/java/com/dongyang/core/api/auth/AuthController.java
@@ -33,27 +33,27 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 
     private final AuthServiceProvider authServiceProvider;
-    private final CreateTokenService createTokenService;
     private final CommonAuthService commonAuthService;
+    private final CreateTokenService createTokenService;
+
 
     @Operation(summary = "OAuth2 소셜 회원가입")
     @PostMapping("/auth/signup")
-    public ApiResponse<TokenResponse> signUp(@Valid @RequestBody SignUpRequest request, HttpServletResponse response) {
+    public ApiResponse<Void> signUp(@Valid @RequestBody SignUpRequest request, HttpServletResponse response) {
         AuthService authService = authServiceProvider.getAuthService(request.getSocialType());
-        Long memberId = authService.signUp(request);
+        TokenResponse tokenInfo = authService.signUp(request);
 
-        addTokensToCookie(createTokenService.createTokenInfo(memberId), response);
+        addTokensToCookie(tokenInfo, response);
 
         return ApiResponse.success(OAUTH_LOGIN_SUCCESS);
     }
 
     @Operation(summary = "OAuth2 소셜 로그인")
     @PostMapping("/auth/login")
-    public ApiResponse<TokenResponse> login(@Valid @RequestBody LoginRequest request, HttpServletResponse response) {
+    public ApiResponse<Void> login(@Valid @RequestBody LoginRequest request, HttpServletResponse response) {
         AuthService authService = authServiceProvider.getAuthService(request.getSocialType());
-        Long memberId = authService.login(request);
-
-        addTokensToCookie(createTokenService.createTokenInfo(memberId), response);
+        TokenResponse tokenInfo = authService.login(request);
+        addTokensToCookie(tokenInfo, response);
         
         return ApiResponse.success(OAUTH_LOGIN_SUCCESS);
     }

--- a/src/main/java/com/dongyang/core/api/auth/service/AuthService.java
+++ b/src/main/java/com/dongyang/core/api/auth/service/AuthService.java
@@ -2,10 +2,11 @@ package com.dongyang.core.api.auth.service;
 
 import com.dongyang.core.api.auth.dto.request.LoginRequest;
 import com.dongyang.core.api.auth.dto.request.SignUpRequest;
+import com.dongyang.core.api.auth.dto.response.TokenResponse;
 
 public interface AuthService {
 
-	Long signUp(SignUpRequest request);
+	TokenResponse signUp(SignUpRequest request);
 
-	Long login(LoginRequest request);
+	TokenResponse login(LoginRequest request);
 }

--- a/src/main/java/com/dongyang/core/api/auth/service/impl/GithubAuthService.java
+++ b/src/main/java/com/dongyang/core/api/auth/service/impl/GithubAuthService.java
@@ -1,5 +1,7 @@
 package com.dongyang.core.api.auth.service.impl;
 
+import com.dongyang.core.api.auth.dto.response.TokenResponse;
+import com.dongyang.core.api.auth.service.CreateTokenService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,18 +28,22 @@ public class GithubAuthService implements AuthService {
 	private final MemberRepository memberRepository;
 
 	private final MemberService memberService;
+	private final CreateTokenService createTokenService;
 
 	@Override
-	public Long signUp(SignUpRequest request) {
+	public TokenResponse signUp(SignUpRequest request) {
 		GithubProfileResponse response = githubApiCaller.getProfileInfo(request.getToken());
-		return memberService.registerMember(request.toCreateMemberDto(response));
+		Long memberId = memberService.registerMember(request.toCreateMemberDto(response));
+
+		return createTokenService.createTokenInfo(memberId);
 	}
 
 	@Override
-	public Long login(LoginRequest request) {
+	public TokenResponse login(LoginRequest request) {
 		GithubProfileResponse response = githubApiCaller.getProfileInfo(request.getToken());
 		Member member = MemberServiceUtils.findMemberBySocialIdAndSocialType(memberRepository, response.getId(),
 			MemberSocialType.GITHUB);
-		return member.getId();
+
+		return createTokenService.createTokenInfo(member.getId());
 	}
 }

--- a/src/main/java/com/dongyang/core/api/auth/service/impl/KakaoAuthService.java
+++ b/src/main/java/com/dongyang/core/api/auth/service/impl/KakaoAuthService.java
@@ -1,7 +1,9 @@
 package com.dongyang.core.api.auth.service.impl;
 
+import com.dongyang.core.api.auth.dto.response.TokenResponse;
 import com.dongyang.core.api.auth.service.AuthService;
 import com.dongyang.core.api.auth.dto.request.LoginRequest;
+import com.dongyang.core.api.auth.service.CreateTokenService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,18 +28,22 @@ public class KakaoAuthService implements AuthService {
 	private final MemberRepository memberRepository;
 
 	private final MemberService memberService;
+	private final CreateTokenService createTokenService;
 
 	@Override
-	public Long signUp(SignUpRequest request) {
+	public TokenResponse signUp(SignUpRequest request) {
 		KakaoProfileResponse response = kakaoApiCaller.getProfileInfo(request.getToken());
-		return memberService.registerMember(request.toCreateMemberDto(response));
+		Long memberId = memberService.registerMember(request.toCreateMemberDto(response));
+
+		return createTokenService.createTokenInfo(memberId);
 	}
 
 	@Override
-	public Long login(LoginRequest request) {
+	public TokenResponse login(LoginRequest request) {
 		KakaoProfileResponse response = kakaoApiCaller.getProfileInfo(request.getToken());
 		Member member = MemberServiceUtils.findMemberBySocialIdAndSocialType(memberRepository, response.getId(),
 			MemberSocialType.KAKAO);
-		return member.getId();
+
+		return createTokenService.createTokenInfo(member.getId());
 	}
 }

--- a/src/main/java/com/dongyang/core/global/common/filter/rateLimit/RateLimitFilter.java
+++ b/src/main/java/com/dongyang/core/global/common/filter/rateLimit/RateLimitFilter.java
@@ -1,9 +1,9 @@
 package com.dongyang.core.global.common.filter.rateLimit;
 
+import com.dongyang.core.api.member.service.MemberServiceUtils;
 import com.dongyang.core.domain.member.Member;
 import com.dongyang.core.domain.member.MemberRole;
 import com.dongyang.core.domain.member.repository.MemberRepository;
-import com.dongyang.core.api.member.service.MemberServiceUtils;
 import com.dongyang.core.global.common.exception.model.RateLimitException;
 import com.dongyang.core.global.common.utils.JwtUtils;
 import com.dongyang.core.global.response.ErrorCode;

--- a/src/main/java/com/dongyang/core/global/common/interceptor/auth/AuthInterceptor.java
+++ b/src/main/java/com/dongyang/core/global/common/interceptor/auth/AuthInterceptor.java
@@ -1,17 +1,13 @@
 package com.dongyang.core.global.common.interceptor.auth;
 
+import com.dongyang.core.global.common.constants.auth.JwtKey;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Optional;
-
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
-
-import com.dongyang.core.global.common.constants.auth.JwtKey;
-
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Component

--- a/src/main/java/com/dongyang/core/global/common/utils/JwtUtils.java
+++ b/src/main/java/com/dongyang/core/global/common/utils/JwtUtils.java
@@ -1,19 +1,13 @@
 package com.dongyang.core.global.common.utils;
 
-import static com.dongyang.core.global.common.constants.message.AuthErrorMessage.*;
-
-import java.security.Key;
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Component;
+import static com.dongyang.core.global.common.constants.message.AuthErrorMessage.EMPTY_CLAIMS_JWT_TOKEN_ERROR_MESSAGE;
+import static com.dongyang.core.global.common.constants.message.AuthErrorMessage.EXPIRED_JWT_TOKEN_ERROR_MESSAGE;
+import static com.dongyang.core.global.common.constants.message.AuthErrorMessage.INVALID_JWT_TOKEN_ERROR_MESSAGE;
+import static com.dongyang.core.global.common.constants.message.AuthErrorMessage.UNHANDLED_JWT_TOKEN_ERROR_MESSAGE;
+import static com.dongyang.core.global.common.constants.message.AuthErrorMessage.UNSUPPORTED_JWT_TOKEN_ERROR_MESSAGE;
 
 import com.dongyang.core.global.common.constants.auth.JwtKey;
 import com.dongyang.core.global.common.constants.auth.RedisKey;
-
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -23,7 +17,14 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.io.DecodingException;
 import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j

--- a/src/main/java/com/dongyang/core/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/dongyang/core/global/config/redis/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.dongyang.core.global.config.redis;
 
+import jakarta.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
@@ -10,7 +11,7 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.session.data.redis.config.ConfigureRedisAction;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -21,32 +22,25 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableTransactionManagement
 public class RedisConfig {
 
-	private final RedisProperties redisProperties;
-	private final DataSource dataSource;
+    private final RedisProperties redisProperties;
 
-	@Bean
-	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
-	}
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
 
-	@Bean
-	public RedisTemplate<String, Object> redisTemplate() {
-		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-		redisTemplate.setConnectionFactory(redisConnectionFactory());
-		redisTemplate.setKeySerializer(new StringRedisSerializer());
-		redisTemplate.setValueSerializer(new StringRedisSerializer());
-		redisTemplate.setEnableTransactionSupport(true); // Redis Transaction ON
-		return redisTemplate;
-	}
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setEnableTransactionSupport(true); // Redis Transaction ON
+        return redisTemplate;
+    }
 
-	// 트랜잭션 적용을 위한 TransactionManager Bean 등록
-	@Bean
-	public PlatformTransactionManager transactionManager() {
-		return new DataSourceTransactionManager(dataSource);
-	}
-
-	@Bean
-	public ConfigureRedisAction configureRedisAction() {
-		return ConfigureRedisAction.NO_OP;
-	}
+    @Bean
+    public ConfigureRedisAction configureRedisAction() {
+        return ConfigureRedisAction.NO_OP;
+    }
 }

--- a/src/main/java/com/dongyang/core/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/dongyang/core/global/config/redis/RedisConfig.java
@@ -1,5 +1,7 @@
 package com.dongyang.core.global.config.redis;
 
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,16 +10,19 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.session.data.redis.config.ConfigureRedisAction;
-
-import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @RequiredArgsConstructor
 @Configuration
 @EnableRedisRepositories
+@EnableTransactionManagement
 public class RedisConfig {
 
 	private final RedisProperties redisProperties;
+	private final DataSource dataSource;
 
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
@@ -30,7 +35,14 @@ public class RedisConfig {
 		redisTemplate.setConnectionFactory(redisConnectionFactory());
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.setEnableTransactionSupport(true); // Redis Transaction ON
 		return redisTemplate;
+	}
+
+	// 트랜잭션 적용을 위한 TransactionManager Bean 등록
+	@Bean
+	public PlatformTransactionManager transactionManager() {
+		return new DataSourceTransactionManager(dataSource);
 	}
 
 	@Bean


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #53 

## 🔑 Key Changes
1. 회정정보 저장, 토큰 저장 로직을 하나의 트랜잭션으로 병합
2. Redis, JPA 트랜잭션 통합하여 원자성 보장하도록 설정

## 📢 To Reviewers

